### PR TITLE
feat: add isDelux attribute to hotel schema

### DIFF
--- a/src/api/hotel/content-types/hotel/schema.json
+++ b/src/api/hotel/content-types/hotel/schema.json
@@ -70,6 +70,11 @@
       "type": "boolean",
       "default": false
     },
+    "isDelux": {
+      "type": "boolean",
+      "required": false,
+      "default": false
+    },
     "contentfulSlug": {
       "type": "string"
     },

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -740,6 +740,7 @@ export interface ApiHotelHotel extends Struct.CollectionTypeSchema {
     externalSource: Schema.Attribute.String;
     gallery: Schema.Attribute.Media<'images', true>;
     isAdultsOnly: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    isDelux: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     latitude: Schema.Attribute.String;
     level: Schema.Attribute.Integer;
     locale: Schema.Attribute.String & Schema.Attribute.Private;


### PR DESCRIPTION
This pull request adds a new optional boolean field to the hotel schema. The new field, `isDelux`, can be used to indicate whether a hotel is deluxe, with a default value of `false`.

* Schema update:
  * Added an optional boolean field `isDelux` with a default value of `false` to the `hotel` content type schema (`src/api/hotel/content-types/hotel/schema.json`).